### PR TITLE
Bug: Value type error on payload bucket creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,7 +96,7 @@ data "aws_iam_policy_document" "allow_organization_read" {
 
     principals {
       type        = "AWS"
-      identifiers = data.aws_organizations_organization.current.arn
+      identifiers = [data.aws_organizations_organization.current.arn]
     }
 
     actions = [


### PR DESCRIPTION
Bug when setting `create_payload_bucket = true`. Expects list instead of sting.
## Error
```sh 
Error: Incorrect attribute value type
│
│   on .terraform/modules/hastus_facade.topic/main.tf line 99, in data "aws_iam_policy_document" "allow_organization_read":
│   99:       identifiers = data.aws_organizations_organization.current.arn
│     ├────────────────
│     │ data.aws_organizations_organization.current.arn is "arn:aws:organizations::276520083766:organization/o-aj60kmnuyc"
│
│ Inappropriate value for attribute "identifiers": set of string required.
╵