### PR TITLE
Add support for fifo topic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "aws_sns_topic" "this" {
   name = var.is_fifo ? "${var.name}.fifo" : var.name
 
-  fifo_topic = var.is_fifo
+  fifo_topic                  = var.is_fifo
   content_based_deduplication = var.use_content_based_deduplication
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,8 @@
 resource "aws_sns_topic" "this" {
-  name = var.name
+  name = var.is_fifo ? "${var.name}.fifo" : var.name
+
+  fifo_topic = var.is_fifo
+  content_based_deduplication = var.use_content_based_deduplication
 }
 
 data "aws_organizations_organization" "current" {}
@@ -73,7 +76,7 @@ data "aws_caller_identity" "current" {}
 
 resource "aws_s3_bucket" "large_message_payload" {
   count  = var.create_payload_bucket ? 1 : 0
-  bucket = "${data.aws_caller_identity.current.account_id}-sns-payloads-for-${var.name}"
+  bucket = "${data.aws_caller_identity.current.account_id}-sns-payloads-for-${var.name}${var.is_fifo ? ".fifo" : ""}"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "large_messages_bucket_lifecycle_configuration" {

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,11 @@ variable "name" {
   description = "The name of the topic"
 
   type = string
+
+  validation {
+    condition     = !can(regex("\\.fifo$", var.name))
+    error_message = "Use the is_fifo variable to create a FIFO topic."
+  }
 }
 
 variable "allowed_external_subscribers" {
@@ -30,4 +35,18 @@ variable "payload_bucket_expiration_days" {
 
   type    = number
   default = 7
+}
+
+variable "is_fifo" {
+  description = "Create a FIFO topic"
+
+  type    = bool
+  default = false
+}
+
+variable "use_content_based_deduplication" {
+  description = "Enables content-based deduplication for FIFO topic"
+
+  type    = bool
+  default = false
 }


### PR DESCRIPTION
## Changes
* Variable `is_fifo` to create fifo topic. Nb! replaces old topic if changed. Same syntax as for https://github.com/nsbno/terraform-aws-queue
* variable `use_content_based_deduplication` for enbelaling content based deduplication. Enables content-based deduplication for FIFO topics. See the [related documentation](https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html)
* Supports payload bucket